### PR TITLE
서버 설정에 영향을 주지 않고 타임스템프 만들도록 개선

### DIFF
--- a/MultiDrmSample.php
+++ b/MultiDrmSample.php
@@ -1,6 +1,4 @@
 <?php
-	date_default_timezone_set('UTC');
-
 	require 'vendor/autoload.php';
 	use Firebase\JWT\JWT;
 
@@ -117,7 +115,7 @@
 
 	// function - inkaDRM 페이로드 생성 
 	function createInkaPayload($clientUserId, $cid) {
-		$timestamp = date("Y-m-d")."T".date("H:i:s")."Z";  // inkaDRM TimeStemp
+		$timestamp = gmdate('c');  // inkaDRM TimeStemp
 		$drmType = getStreamingType()[0];                  // inkaDRM DRM Type
 
 		// step1 - 설정 값 입력


### PR DESCRIPTION
안녕하세요.

date_default_timezone_set 함수를 사용하게되면 해당 함수의 의해서 전체적인 php의 날자 형식이 GMT+0 시간으로 맞춰버리게 되어 php사이트들에 시간기록에 지대한 영향을 미칠 수 있습니다.

GMT+0시간을 가져오는 방식은 gmdate함수를 호출하는 것이 정석이고 타임스템프에 맞는 형식을 출력하기 위해서는 해당 파라미터를 'c'로 넘기는것이 정석입니다.

해당 코드 정상작동 확인하여 PR을 남겨드립니다.

리뷰해주셔서 감사합니다.